### PR TITLE
Return parse errors from ParseRange

### DIFF
--- a/range.go
+++ b/range.go
@@ -45,10 +45,9 @@ func ParseRange(rangeStr string) (*Range, error) {
 		} else {
 			min, err := strconv.ParseFloat(rangeStr[0:endPos], 64)
 			if err != nil {
-				fmt.Println("failed to parse lower limit:", err)
-			} else {
-				t.Start = min
+				return nil, fmt.Errorf("failed to parse lower limit: %v", err)
 			}
+			t.Start = min
 		}
 		rangeStr = rangeStr[endPos+1:]
 	}
@@ -57,10 +56,9 @@ func ParseRange(rangeStr string) (*Range, error) {
 	if len(rangeStr) > 0 {
 		max, err := strconv.ParseFloat(rangeStr, 64)
 		if err != nil {
-			fmt.Println("failed to parse upper limit:", err)
-		} else {
-			t.End = max
+			return nil, fmt.Errorf("failed to parse upper limit: %v", err)
 		}
+		t.End = max
 	}
 
 	if t.End < t.Start {

--- a/range_test.go
+++ b/range_test.go
@@ -6,189 +6,159 @@ import (
 
 // see https://www.monitoring-plugins.org/doc/guidelines.html#THRESHOLDFORMAT
 
-func TestRange(t *testing.T) {
+// TestInsideRange ensures that an explicitly bounded range only accepts
+// values within the range.
+func TestInsideRange(t *testing.T) {
 	var r *Range
 	var err error
-	var pat string
 
-	// true   => raise alert
-	// false  => ok (no alert)
+	rangeStr := "10:20"
+	r, err = ParseRange(rangeStr)
+	if err != nil {
+		t.Fatalf("Failed to parse %v: %v", rangeStr, err)
+	}
 
-	/*
-	 * Case 1: Pattern "10" -> Range {0..10}
-	 * Tests:
-	 * -1   -> true
-	 *  0   -> false
-	 *  5   -> false
-	 * 10   -> false
-	 * 11   -> true
-	 */
-	pat = "10"
-	r, err = ParseRange(pat)
+	tests := []struct {
+		value       float64
+		shouldAlert bool
+	}{
+		{-1.0, true},
+		{0.0, true},
+		{1.0, true},
+		{9.0, true},
+		{10.0, false},
+		{15.0, false},
+		{20.0, false},
+		{21.0, true},
+	}
+	for _, test := range tests {
+		didAlert := r.Check(test.value)
+		if didAlert != test.shouldAlert {
+			t.Errorf("Check(%v) should be %v", test.value, test.shouldAlert)
+		}
+	}
+}
+
+// TestOutsideRange ensures that an explicitly bounded range prefixed
+// with the at sign (@) only accepts values outside the range.
+func TestOutsideRange(t *testing.T) {
+	var r *Range
+	var err error
+
+	rangeStr := "@10:20"
+	r, err = ParseRange(rangeStr)
 	if err != nil {
-		t.Fatalf("Failed to parse %v: %v", pat, err)
+		t.Fatalf("Failed to parse %v: %v", rangeStr, err)
 	}
-	if !r.Check(-1.0) {
-		t.Errorf("Check -1.0 should be true")
+
+	tests := []struct {
+		value       float64
+		shouldAlert bool
+	}{
+		{-1.0, false},
+		{0.0, false},
+		{1.0, false},
+		{9.0, false},
+		{10.0, true},
+		{15.0, true},
+		{20.0, true},
+		{21.0, false},
 	}
-	if r.Check(0.0) {
-		t.Errorf("Check 0.0 should be false")
+	for _, test := range tests {
+		didAlert := r.Check(test.value)
+		if didAlert != test.shouldAlert {
+			t.Errorf("Check(%v) should be %v", test.value, test.shouldAlert)
+		}
 	}
-	if r.Check(5.0) {
-		t.Errorf("Check 5.0 should be false")
-	}
-	if r.Check(10.0) {
-		t.Errorf("Check 10.0 should be false")
-	}
-	if !r.Check(11.0) {
-		t.Errorf("Check 11.0 should be true")
-	}
-	/*
-	 * Case 2: Pattern: "10:" -> Range {10..inf}
-	 * Tests:
-	 * -1   -> true
-	 *  0   -> true
-	 *  1   -> true
-	 *  5   -> true
-	 * 10   -> false
-	 * 11   -> false
-	 */
-	pat = "10:"
-	r, err = ParseRange(pat)
+}
+
+// TestImpliedMinimumRange ensures that a range string with no explicit
+// minimum defaults to a minimum of 0.
+func TestImpliedMinimumRange(t *testing.T) {
+	var r *Range
+	var err error
+
+	rangeStr := "10"
+	r, err = ParseRange(rangeStr)
 	if err != nil {
-		t.Fatalf("Failed to parse %v: %v", pat, err)
+		t.Fatalf("Failed to parse %v: %v", rangeStr, err)
 	}
-	if !r.Check(-1.0) {
-		t.Errorf("Check -1.0 should be true")
+
+	tests := []struct {
+		value       float64
+		shouldAlert bool
+	}{
+		{-1.0, true},
+		{0.0, false},
+		{5.0, false},
+		{11.0, true},
 	}
-	if !r.Check(0.0) {
-		t.Errorf("Check 0.0 should be true")
+	for _, test := range tests {
+		didAlert := r.Check(test.value)
+		if didAlert != test.shouldAlert {
+			t.Errorf("Check(%v) should be %v", test.value, test.shouldAlert)
+		}
 	}
-	if !r.Check(1.0) {
-		t.Errorf("Check 1.0 should be true")
-	}
-	if !r.Check(5.0) {
-		t.Errorf("Check 10.0 should be true")
-	}
-	if r.Check(10.0) {
-		t.Errorf("Check 10.0 should be false")
-	}
-	if r.Check(11.0) {
-		t.Errorf("Check 11.0 should be false")
-	}
-	/*
-	 * Case 3: Pattern: "~:10" -> Range {-inf..10}
-	 * Tests:
-	 * -1   -> false
-	 *  0   -> false
-	 *  1   -> false
-	 *  5   -> false
-	 * 10   -> false
-	 * 11   -> true
-	 */
-	pat = "~:10"
-	r, err = ParseRange(pat)
+}
+
+// TestImpliedMaximumRange ensures that a range string with no explicit
+// maximum defaults to a maximum of +Inf.
+func TestImpliedMaximumRange(t *testing.T) {
+	var r *Range
+	var err error
+
+	rangeStr := "10:"
+	r, err = ParseRange(rangeStr)
 	if err != nil {
-		t.Fatalf("Failed to parse %v: %v", pat, err)
+		t.Fatalf("Failed to parse %v: %v", rangeStr, err)
 	}
-	if r.Check(-1.0) {
-		t.Errorf("Check -1.0 should be false")
+
+	tests := []struct {
+		value       float64
+		shouldAlert bool
+	}{
+		{-1.0, true},
+		{0.0, true},
+		{1.0, true},
+		{5.0, true},
+		{10.0, false},
+		{11.0, false},
 	}
-	if r.Check(0.0) {
-		t.Errorf("Check 0.0 should be false")
+	for _, test := range tests {
+		didAlert := r.Check(test.value)
+		if didAlert != test.shouldAlert {
+			t.Errorf("Check(%v) should be %v", test.value, test.shouldAlert)
+		}
 	}
-	if r.Check(1.0) {
-		t.Errorf("Check 1.0 should be false")
-	}
-	if r.Check(5.0) {
-		t.Errorf("Check 10.0 should be false")
-	}
-	if r.Check(10.0) {
-		t.Errorf("Check 10.0 should be false")
-	}
-	if !r.Check(11.0) {
-		t.Errorf("Check 11.0 should be true")
-	}
-	/*
-	 * Case 4: Pattern: "10:20" -> Range {10..20}
-	 * Tests:
-	 * -1   -> true
-	 *  0   -> true
-	 *  1   -> true
-	 *  9   -> true
-	 * 10   -> false
-	 * 15   -> false
-	 * 20   -> false
-	 * 21   -> true
-	 */
-	pat = "10:20"
-	r, err = ParseRange(pat)
+}
+
+// TestNegInfRange ensures that a range string with a minimum bound of a
+// tilde is correctly interpreted to mean -Inf.
+func TestNegInfRange(t *testing.T) {
+	var r *Range
+	var err error
+
+	rangeStr := "~:10"
+	r, err = ParseRange(rangeStr)
 	if err != nil {
-		t.Fatalf("Failed to parse %v: %v", pat, err)
+		t.Fatalf("Failed to parse %v: %v", rangeStr, err)
 	}
-	if !r.Check(-1.0) {
-		t.Errorf("Check -1.0 should be true")
+
+	tests := []struct {
+		value       float64
+		shouldAlert bool
+	}{
+		{-1.0, false},
+		{0.0, false},
+		{1.0, false},
+		{5.0, false},
+		{10.0, false},
+		{11.0, true},
 	}
-	if !r.Check(0.0) {
-		t.Errorf("Check 0.0 should be true")
-	}
-	if !r.Check(1.0) {
-		t.Errorf("Check 1.0 should be true")
-	}
-	if !r.Check(9.0) {
-		t.Errorf("Check 9.0 should be true")
-	}
-	if r.Check(10.0) {
-		t.Errorf("Check 10.0 should be false")
-	}
-	if r.Check(15.0) {
-		t.Errorf("Check 15.0 should be false")
-	}
-	if r.Check(20.0) {
-		t.Errorf("Check 20.0 should be false")
-	}
-	if !r.Check(21.0) {
-		t.Errorf("Check 21.0 should be true")
-	}
-	/*
-	 * Case 5: Pattern: "@10:20" -> Range !{10..20}
-	 * Tests:
-	 * -1   -> false
-	 *  0   -> false
-	 *  1   -> false
-	 *  9   -> false
-	 * 10   -> true
-	 * 15   -> true
-	 * 20   -> true
-	 * 21   -> false
-	 */
-	pat = "@10:20"
-	r, err = ParseRange(pat)
-	if err != nil {
-		t.Fatalf("Failed to parse %v: %v", pat, err)
-	}
-	if r.Check(-1.0) {
-		t.Errorf("Check -1.0 should be false")
-	}
-	if r.Check(0.0) {
-		t.Errorf("Check 0.0 should be false")
-	}
-	if r.Check(1.0) {
-		t.Errorf("Check 1.0 should be false")
-	}
-	if r.Check(9.0) {
-		t.Errorf("Check 9.0 should be false")
-	}
-	if !r.Check(10.0) {
-		t.Errorf("Check 10.0 should be true")
-	}
-	if !r.Check(15.0) {
-		t.Errorf("Check 15.0 should be true")
-	}
-	if !r.Check(20.0) {
-		t.Errorf("Check 20.0 should be true")
-	}
-	if r.Check(21.0) {
-		t.Errorf("Check 21.0 should be false")
+	for _, test := range tests {
+		didAlert := r.Check(test.value)
+		if didAlert != test.shouldAlert {
+			t.Errorf("Check(%v) should be %v", test.value, test.shouldAlert)
+		}
 	}
 }

--- a/range_test.go
+++ b/range_test.go
@@ -162,3 +162,20 @@ func TestNegInfRange(t *testing.T) {
 		}
 	}
 }
+
+// TestInvalidRanges ensures that ParseRange correctly fails on input
+// that is known to be invalid.
+func TestInvalidRanges(t *testing.T) {
+	var err error
+
+	badRanges := []string{
+		"20:10", // Violates min <= max
+		"10,20", // The comma is non-sensical
+	}
+	for _, rangeStr := range badRanges {
+		_, err = ParseRange(rangeStr)
+		if err == nil {
+			t.Errorf("ParseRange(%v) should have returned an error", rangeStr)
+		}
+	}
+}


### PR DESCRIPTION
The README includes this snippet in its example usage:

```go
    // Parse a range from the command line and warn on a match.
    warnRange, err := nagiosplugin.ParseRange( "1:2" )
    if err != nil {
        check.AddResult(nagiosplugin.UNKNOWN, "error parsing warning range")
    }
```

Since the input to `ParseRange()` is (at least partially) user-supplied in practice, I tried changing the string `"1:2"` to something silly expecting an UNKNOWN ultimate check result.  Instead, I received output on stdout that violated the [prescribed output format for Nagios plugins](https://nagios-plugins.org/doc/guidelines.html#PLUGOUTPUT).

This pull request should make actual behaviour align with the expectations set by the README.