### PR TITLE
Don't run the check example test

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -30,6 +30,6 @@ func Example() {
 	// if there's more than one, the highest result will be the one
 	// returned (in ascending order OK, WARNING, CRITICAL, UNKNOWN).
 
-	// Output:
+	// This will print:
 	// OK: Everything looks shiny from here, cap'n | badness=3.141592653589793;4000;9000;0;
 }


### PR DESCRIPTION
It exits the test runner, and thus invalidates the rest of the
testsuite. Removing the "// Output:" comment ensures that the example
compiles, but does not run it.

Fixes #4.