### PR TITLE
Make WARNING/CRITICAL supersede UNKNOWN status

### DIFF
--- a/check.go
+++ b/check.go
@@ -38,7 +38,12 @@ func (c *Check) AddResult(status Status, message string) {
 	result.status = status
 	result.message = message
 	c.results = append(c.results, result)
-	if result.status > c.status {
+
+	if result.status == UNKNOWN {
+		if c.status == OK {
+			c.status = result.status
+		}
+	} else if result.status > c.status {
 		c.status = result.status
 	}
 }


### PR DESCRIPTION
Hello!

This PR will change the way nagiosplugin interprets multiple check results as added by `AddResult()`.

Before:  [WARNING, UNKNOWN] -> UNKNOWN

After:  [WARNING, UNKNOWN] -> WARNING

To explain why I think this change is needed, let's go back to what these 'plugin return codes' (as Nagios calls them) mean in practice:

  * WARNING and CRITICAL:  The plugin has positively identified something that is *almost certainly* broken.
  * UNKNOWN:  The plugin *cannot be sure* whether something is broken because it could not acquire sufficient data to reach a decision.

Non-trivial plugins will typically check multiple data points before returning a final result.  Suppose I am trying to monitor my old washing machine.  I sample from two sensors, a vibration sensor, and a sensor that tells me whether the floor is wet from a leak.  I know from experience that should either sensor report a value outside its thresholds then there is a definite problem.  This is true regardless of what the other sensor says -- or whether the other sensor is even attached and working.  In pseudocode:

    func checkVibrations() {
        vibrations, err = queryVibrationSensor()
        if err {
            check.AddResult(UNKNOWN, "Unable to query vibration sensor")
            return
        }
        if vibrations > vibrationThreshold {
            check.AddResult(OK, "...")
        } else {
            check.AddResult(CRITICAL, "...")
        }
    }

    func checkLeaks() {
        leakiness, err = queryWaterSensor()
        if err {
            check.AddResult(UNKNOWN, "Unable to query water sensor")
            return
        }
        // and so on
    }

    checkVibrations()
    checkLeaks()

With current behaviour, if I unplug the vibration sensor, any real fault detected by the water leakage sensor will be hidden behind an UNKNOWN.  The check is able to positively identify a fault using partial data.  I think this is the common case.  We should optimise for it.
