### PR TITLE
Add NewOUWCStatusPolicy() and document its use

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ func main() {
 }
 ```
 
+In the example above, multiple results were added to the check with `AddResult()`. The final state of the check will be determined by its most severe result. By default, result severity is ordered to match the plugin return codes documented in the [Nagios plugin developer guidelines][guidelines]. A WARNING result is considered more severe than OK, CRITICAL more severe than WARNING, and UNKNOWN most severe of all. A status policy may be used to modify this default behaviour:
+
+```go
+func main() {
+	check := nagiosplugin.NewCheckWithOptions(nagiosplugin.CheckOptions{
+		// OK -> UNKNOWN -> WARNING -> CRITICAL
+		StatusPolicy: nagiosplugin.NewOUWCStatusPolicy(),
+	})
+	defer check.Finish()
+
+	// Now, any WARNING or CRITICAL results added to the check will be
+	// considered more severe than any UNKNOWN result.
+}
+```
+
+[guidelines]: https://nagios-plugins.org/doc/guidelines.html
+
 # Language version
 
 Requires go >= 1.0; tested with versions up to 1.5.

--- a/check_test.go
+++ b/check_test.go
@@ -36,10 +36,9 @@ func TestDefaultStatusPolicy(t *testing.T) {
 	}
 }
 
-func TestCustomStatusPolicy(t *testing.T) {
-	p, _ := NewStatusPolicy([]Status{OK, UNKNOWN, WARNING, CRITICAL})
+func TestOUWCStatusPolicy(t *testing.T) {
 	c := NewCheckWithOptions(CheckOptions{
-		StatusPolicy: p,
+		StatusPolicy: NewOUWCStatusPolicy(),
 	})
 	c.AddResult(WARNING, "Isolated-frame flux emission outside threshold")
 	c.AddResult(UNKNOWN, "No response from betaform amplifier")

--- a/result.go
+++ b/result.go
@@ -35,6 +35,15 @@ func NewDefaultStatusPolicy() *statusPolicy {
 	}
 }
 
+// NewOUWCStatusPolicy returns a status policy similar to that returned
+// by NewDefaultStatusPolicy with one difference: the UNKNOWN check
+// status is demoted in severity such that any WARNING or CRITICAL check
+// status will take priority.
+func NewOUWCStatusPolicy() *statusPolicy {
+	pol, _ := NewStatusPolicy([]Status{OK, UNKNOWN, WARNING, CRITICAL})
+	return pol
+}
+
 // NewStatusPolicy returns a status policy that assigns relative
 // severity in accordance with a user-configurable prioritised slice.
 // Check statuses must be listed in ascending severity order.


### PR DESCRIPTION
@cosmopetrich offered me some feedback on #9 that I was regrettably unable to include prior to the merge.  I have incorporated it here.  His feedback was twofold:

1. Document the use of the new 'status policy' feature in the README so that users are at least aware of it.
2. Of all 4! potential permutations of result ordering, we figure the majority of users will opt for either the default or the OK -> UNKNOWN -> WARNING -> CRITICAL ordering.  In this PR I have elevated the latter to an easy-to-use preset.  Pithy naming suggestions welcome.

No rush on this PR.  Just closing a loop.  :)